### PR TITLE
Fix QR image path in presentation slide

### DIFF
--- a/curso-ia-luarca-slides/slides.md
+++ b/curso-ia-luarca-slides/slides.md
@@ -387,7 +387,7 @@ transition: slide-up
 
 <br>
 
-![qr para la presentación](../recursos/QR.png)
+![qr para la presentación](./recursos/QR.png)
 
 <br>
 


### PR DESCRIPTION
Correct the path for the QR image in the presentation slide to ensure it displays properly.