### PR TITLE
Add example links in LLMs and formatting tools sections

### DIFF
--- a/curso-ia-luarca-slides/pages/context-window.md
+++ b/curso-ia-luarca-slides/pages/context-window.md
@@ -253,9 +253,9 @@ Durante el proceso de inferencia, el modelo trata de reconocer patrones en la in
 ---
 
 # ¡Veámoslo en otro ejemplo!
-El rápido progreso en *GenAI* nos permite usar LLMs en local. Suelen ser versiones "reducidas" adaptadas a las capacidades de nuestra máquina.
+El rápido progreso en *GenAI* nos permite usar LLMs en local. Suelen ser versiones "reducidas" adaptadas a las capacidades de nuestra máquina. [Link ejemplo](https://github.com/jllorian/curso-ia-docentes/blob/main/examples.md#conversaci%C3%B3n-con-deepseek-r1).
 
-[Ollama](https://ollama.com/download) es una herrmienta que permite usar *GenAI* en tu ordedador, sin necesidad de internet.
+[Ollama](https://ollama.com/download) es una herramienta que permite usar *GenAI* en tu ordenador, sin necesidad de internet.
 
 ````md magic-move {lines: true}
 ```zsh {*}

--- a/curso-ia-luarca-slides/slides.md
+++ b/curso-ia-luarca-slides/slides.md
@@ -388,7 +388,7 @@ class: "text-sm"
 # Un último ejemplo
 Forzando formatos
 
-OpenAI dispone de la herramienta [Canvas](https://openai.com/index/introducing-canvas/) integrada en ChatGPT. Para este ejemplo usaremos una herramienta similar de Mistral: [LeChat](https://chat.mistral.ai/), ya que permite más opciones de personalización.
+OpenAI dispone de la herramienta [Canvas](https://openai.com/index/introducing-canvas/) integrada en ChatGPT. Para [este ejemplo](https://github.com/jllorian/curso-ia-docentes/blob/main/examples.md#profesor-de-dibujo-art%C3%ADstico-de-1%C2%BA-de-bachillerato) usaremos una herramienta similar de Mistral: [LeChat](https://chat.mistral.ai/), ya que permite más opciones de personalización.
 
 Pero **nada** nos impide, ante cualquier modelo, indicarle un formato de salida específico en el prompt^[Los modelos de llama3 y ChatGPT-4o tienen un parámetro para forzar el formato de salida. En el caso de llama3, es el parámetro `--output-format` y en el caso de ChatGPT-4o es el parámetro `--format`.] como: `HTML`, `JSON`, o 
 `Markdown`. Pero en otras plataformas, necesitaremos traspasar la respuesta del modelo a otro servicio que represente el formato.


### PR DESCRIPTION
Include links to examples in the LLMs and formatting tools sections of the presentation for better reference and clarity.